### PR TITLE
Minor cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM proger/openling-env
 RUN mkdir -p /usr/src/openling
 ADD . /usr/src/openling
+RUN mkdir -p /usr/src/openling/apps/crypto/ebin
+RUN mkdir -p /usr/src/openling/apps/os_mon/ebin
 RUN (cd /usr/src/openling && ./configure && make install)
 RUN (cd /tmp; touch railing.config; railing image)

--- a/core/Makefile
+++ b/core/Makefile
@@ -154,4 +154,4 @@ lib/nettle/config.h: lib/nettle.tar.gz
 	cd lib/nettle && ./configure --disable-public-key --disable-shared --disable-pic --disable-openssl CFLAGS="-fno-stack-protector -U_FORTIFY_SOURCE"
 
 lib/nettle.tar.gz:
-	wget -O $@ -c https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz
+	wget -O $@ --no-check-certificate -c https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -3,9 +3,8 @@ FROM ubuntu:13.10
 RUN echo deb-src http://archive.ubuntu.com/ubuntu saucy main universe >> /etc/apt/sources.list \
 	&& apt-get update \
 	&& env DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential wget \
-	&& env DEBIAN_FRONTEND=noninteractive apt-get -y build-dep \
 	&& rm -rf /var/cache/apt/archives
-RUN env DEBIAN_FRONTEND=noninteractive apt-get -y install autoconf automake libncursesw5-dev libssl-dev linux-headers-generic \
+RUN env DEBIAN_FRONTEND=noninteractive apt-get -y install nettle-dev autoconf automake libncursesw5-dev libssl-dev linux-headers-generic \
 	&& rm -rf /var/cache/apt/archives
 ADD Makefile /usr/src/Makefile
 RUN make -C /usr/src default && make -C /usr/src/ cleanall


### PR DESCRIPTION
create ebin subdir in crypto and os_mon appdirs

Add nettle-dev to packages, and remove erroneous build-dep

Don't check ftp.gnu.org's https cert when fetching nettle
