### PR TITLE
Build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: erlang
+otp_release: 17.3
+before_install: sudo apt-get update -qq
+install: sudo apt-get install -y nettle-dev
+script: make


### PR DESCRIPTION
Please refer to commit message for details.

In order for Travis CI to build code from the `cloudozer/ling` repo, the repo shall be set up (ref [here](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in) and following).

The next step would be saving `railing/railing` somewhere - maybe using [ref1](https://github.com/blog/1547-release-your-software) and/or [ref2](http://docs.travis-ci.com/user/deployment/releases/).
(BTW link https://github.com/cloudozer/ling/releases/download/v0.3.0/railing-0.3.0 is broken)
