### PR TITLE
Replace recursive calls to `make` with `$(MAKE)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,19 @@ ifneq ($(OTP_VER) , $(shell erl -noshell -eval "io:format(erlang:system_info(otp
 endif
 
 bc:
-	make -C bc
+	$(MAKE) -C bc
 
 core:
-	make -C core
+	$(MAKE) -C core
 
 apps:
-	make -C apps
+	$(MAKE) -C apps
 
 railing:
-	make -C railing
+	$(MAKE) -C railing
 
 test:
-	make -C test beams
+	$(MAKE) -C test beams
 
 install: bc core apps railing
 	install railing/railing /usr/bin

--- a/core/Makefile
+++ b/core/Makefile
@@ -151,7 +151,7 @@ vmling.o: $(STARTUP_OBJ) $(MISC_AS_OBJS) $(ALL_OBJS)
 nettle: lib/nettle/libnettle.a
 
 lib/nettle/libnettle.a: lib/nettle/config.h
-	make -C lib/nettle
+	$(MAKE) -C lib/nettle
 
 lib/nettle/config.h: lib/nettle.tar.gz
 	mkdir -p lib/nettle && tar vxzf $< -C lib/nettle --strip-components=1 && \

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -12,7 +12,8 @@ $(OTP): otp.tar.gz
 	tar xvzf $<
 
 otp: $(OTP)
-	(cd $< && ./otp_build setup --disable-hipe --without-javac && make install)
+	(cd $< && ./otp_build setup --disable-hipe --without-javac)
+	$(MAKE) -C $< install
 
 cleanall:
 	rm -rf $(OTP)


### PR DESCRIPTION
This is the recommended approach in GNU make and I tested that it clarifies Makefile errors.
