### PR TITLE
Use local version of nettle at compilation

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -15,6 +15,7 @@ CPPFLAGS := -D_ISOC99_SOURCE -D_GNU_SOURCE
 CPPFLAGS += -iquote lib
 CPPFLAGS += -isystem lib/misc/include
 CPPFLAGS += -isystem lib/pcre
+CPPFLAGS += -isystem lib
 CPPFLAGS += -iquote include -iquote arch/$(ARCH)/include
 CPPFLAGS += -iquote bignum
 CPPFLAGS += -iquote lib/lwip/src/include


### PR DESCRIPTION
Snippet taken from [PR 14](https://github.com/cloudozer/ling/pull/14/files#diff-ce79deecfd2f89db4ccdd711965c38e6R27) thus I expect this PR to conflict with that one.
