### PR TITLE
Supply instance of `hibernate` call to instructions analysis script

### DIFF
--- a/bc/scripts/beam.src
+++ b/bc/scripts/beam.src
@@ -15,6 +15,7 @@
 @mnesia
 @syntax_tools
 @compiler
+@stdlib
 
 # The analysis must see all possible iops. Rare iops are typically seen in
 # tests.


### PR DESCRIPTION
Supersedes #23 addressing https://github.com/cloudozer/ling/pull/23#issuecomment-68249112.
