### PR TITLE
Express that `bc` needs `test` BEAMs in order to consider rare iops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq ($(OTP_VER) , $(shell erl -noshell -eval "io:format(erlang:system_info(otp
 	$(error Erlang/OTP $(OTP_VER) not found)
 endif
 
-bc:
+bc: test
 	$(MAKE) -C bc
 
 core: bc


### PR DESCRIPTION
Please refer to commit message for details.
