### PR TITLE
Build script, Vagrantfile, CROSS_COMPILE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.railing/
 domain_config
 ling.img
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Thin Vagrant file; eventually this will be expanded to split
+# ./build.sh into separate provision/build components.
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 2048
+  end
+
+  config.vm.provision "shell", path: "build.sh"
+
+end

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+set -x
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Get and install Erlang
+echo "deb http://packages.erlang-solutions.com/debian wheezy contrib" > /etc/apt/sources.list.d/erlang.list
+wget -c http://packages.erlang-solutions.com/debian/erlang_solutions.asc
+sudo apt-key add erlang_solutions.asc
+apt-get update
+apt-get install -y --force-yes erlang git autoconf
+
+# Get and prepare cross-compilation tools
+git clone https://github.com/raspberrypi/tools || true
+export PATH=$PATH:$(pwd)/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
+
+# Get ling
+git clone https://github.com/thenewwazoo/ling.git || true
+cd ling && git checkout raspberry-pi
+
+# Build and make nettle available for including and linking
+
+cd core/lib/    # We do this here because the ling Makefile doesn't handle cross-compilation nicely yet.
+wget -c https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz
+tar zxf nettle-2.7.1.tar.gz
+mv nettle-2.7.1 nettle # rename because ling makefile expects it
+cd nettle 
+./.bootstrap
+./configure --host=arm-linux-gnueabihf
+make CROSS_COMPILE=arm-linux-gnueabihf-
+cd ../../..
+
+make CROSS_COMPILE=arm-linux-gnueabihf-
+echo "Railing built... what next? :)"

--- a/core/Makefile
+++ b/core/Makefile
@@ -7,9 +7,9 @@ include ../Config.mk
 
 ARCH := arm
 
-CROSS_PREFIX := arm-unknown-eabi
-CC := $(CROSS_PREFIX)-gcc
-OBJCOPY := $(CROSS_PREFIX)-objcopy
+CROSS_COMPILE ?= arm-unknown-eabi-
+CC := $(CROSS_COMPILE)gcc
+OBJCOPY := $(CROSS_COMPILE)objcopy
 
 CPPFLAGS := -D_ISOC99_SOURCE -D_GNU_SOURCE
 CPPFLAGS += -isystem lib/nettle

--- a/core/lib/lwip/Makefile
+++ b/core/lib/lwip/Makefile
@@ -1,8 +1,8 @@
 
 TARGET := liblwip.a
 
-CROSS_PREFIX := arm-unknown-eabi
-CC := $(CROSS_PREFIX)-gcc
+CROSS_COMPILE ?= arm-unknown-eabi-
+CC := $(CROSS_COMPILE)gcc
 
 SRC_DIRS := src/api src/core src/core/ipv4 src/core/ipv6
 SRC_DIRS += src/netif

--- a/railing/railing.erl
+++ b/railing/railing.erl
@@ -16,7 +16,7 @@ opt_spec() -> [
 ].
 
 cross_prefix() ->
-    case os:getenv("RAILING_CROSS_PREFIX") of
+    case os:getenv("CROSS_COMPILE") of
         false -> case os:type() of
                     {unix, darwin} -> "x86_64-pc-linux-";
                     _ -> ""


### PR DESCRIPTION
I took the liberty of writing a bash script to start the process of build automation for the RPi images, with a Vagrantfile to match it. I guessed about the toolchain, choosing the arm-linux-gnueabihf that comes from the RPi foundation (but swapping it out should be very simple in the bash script).

I also tweaked the Makefiles to adopt the CROSS_COMPILE Makefile variable convention.

It will successfully build vmling.o and railing, but I'm not sure where to go from there (I only had time to get builds working today). The kernel.img file is much bigger. Perhaps a static link flag I'm missing, or a bootloader?