### PR TITLE
One-step build process for rpi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.railing/
 domain_config
 ling.img
+.vagrant/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,21 +1,30 @@
 
 ## Prerequisites
 
-To build LING from sources, the following prerequisites must be met:
+To build LING from sources for Raspberry Pi, the following prerequisites must be met:
 
 1. Erlang/OTP
 
    You must have [Erlang/OTP release 17 installed](https://www.erlang-solutions.com/downloads/download-erlang-otp).
 
-2. When using OS X, you need to have a [cross-compiling toolchain](http://crossgcc.rts-software.org/doku.php?id=compiling_for_linux)
-   installed on your system. LING has been tested to build against GCC 4.8.1 and 4.9.
+2. Cross compiler
+
+   You must have a suitable bare-metal cross-compiler installed. To build your own, see [crosstool-ng](http://crosstool-ng.org). The gcc-arm-none-eabi package from Ubuntu is also known to work.
+
+3. Autoconf
+
+   The nettle 2.7.1 library requires autoconf for bootstrapping (tested with autoconf 2.69).
 
 ## Build
 
-```
-make
-make install
-```
+To generate a bootable/runnable kernel.img file:
 
-Make sure to run `git clean -dxf` to start over if you see weird error
-messages you can't easily explain.
+1. Download and cross-compile libnettle.a (see build.sh lines 24-28)
+2. Build LING to generate vmling.o, railing executable, and other necessary libraries.
+3. Use `railing` to generate an ELF kernel.
+4. Convert the ELF format to raw binary suitable for booting on the target hardware.
+5. Copy the binary blob to the SD card's FAT partition, overwriting kernel.img there.
+
+## Vagrant
+
+For convenience, a [Vagrantfile](https://www.vagrantup.com) is included. It runs the build.sh script automatically, and will copy a bootable/runnable kernel.img file into the Vagrantfile's directory. From there, perform step 5 above.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Thin Vagrant file; eventually this will be expanded to split
+# ./build.sh into separate provision/build components.
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 2048
+  end
+
+  config.vm.provision "shell", path: "build.sh"
+
+end

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+set -x
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Get and install Erlang
+sudo sh -c 'echo "deb http://packages.erlang-solutions.com/debian wheezy contrib" > /etc/apt/sources.list.d/erlang.list'
+wget -c http://packages.erlang-solutions.com/debian/erlang_solutions.asc
+sudo apt-key add erlang_solutions.asc
+sudo apt-get update
+sudo apt-get install -y --force-yes erlang git autoconf gcc-arm-none-eabi
+
+# Get ling
+git clone https://github.com/thenewwazoo/ling.git || true
+cd ling && git checkout raspberry-pi
+
+# Build and make nettle available for including and linking
+cd core/lib/    # We do this here because the ling Makefile doesn't handle cross-compilation nicely yet.
+wget -c https://ftp.gnu.org/gnu/nettle/nettle-2.7.1.tar.gz
+tar zxf nettle-2.7.1.tar.gz
+ln -s nettle-2.7.1 nettle # Makefile and includes expect nettle dir.
+cd nettle 
+./.bootstrap
+# newlib doesn't support assert very well, so set NDEBUG to elide asserts and prevent undefined ref errors at link time.
+CFLAGS='-DNDEBUG --specs=nosys.specs -mfloat-abi=hard -mfpu=vfp' ./configure --host=arm-none-eabi
+make -j4 CROSS_COMPILE=arm-none-eabi- libnettle.a # All we need is libnettle.a and some headers.
+cd ../../..
+
+make CROSS_COMPILE=arm-none-eabi-
+cd railing
+CROSS_COMPILE=arm-none-eabi- ./railing image -n kernel
+mv kernel.img kernel.elf
+arm-none-eabi-objcopy -O binary kernel.elf kernel.img
+cp kernel.img /vagrant/

--- a/core/Makefile
+++ b/core/Makefile
@@ -7,9 +7,9 @@ include ../Config.mk
 
 ARCH := arm
 
-CROSS_PREFIX := arm-unknown-eabi
-CC := $(CROSS_PREFIX)-gcc
-OBJCOPY := $(CROSS_PREFIX)-objcopy
+CROSS_COMPILE ?= arm-unknown-eabi-
+CC := $(CROSS_COMPILE)gcc
+OBJCOPY := $(CROSS_COMPILE)objcopy
 
 CPPFLAGS := -D_ISOC99_SOURCE -D_GNU_SOURCE
 CPPFLAGS += -isystem lib/nettle

--- a/core/lib/lwip/Makefile
+++ b/core/lib/lwip/Makefile
@@ -1,8 +1,8 @@
 
 TARGET := liblwip.a
 
-CROSS_PREFIX := arm-unknown-eabi
-CC := $(CROSS_PREFIX)-gcc
+CROSS_COMPILE ?= arm-unknown-eabi-
+CC := $(CROSS_COMPILE)gcc
 
 SRC_DIRS := src/api src/core src/core/ipv4 src/core/ipv6
 SRC_DIRS += src/netif

--- a/railing/railing.erl
+++ b/railing/railing.erl
@@ -16,7 +16,7 @@ opt_spec() -> [
 ].
 
 cross_prefix() ->
-    case os:getenv("RAILING_CROSS_PREFIX") of
+    case os:getenv("CROSS_COMPILE") of
         false -> case os:type() of
                     {unix, darwin} -> "x86_64-pc-linux-";
                     _ -> ""


### PR DESCRIPTION
Sorry for the noise. I've now got the build process tested on hardware.

PR includes:
- minor tweaking of Makefiles to adopt CROSS_COMPILE convention
- added a Vagrantfile to avoid compile environment troubles (and .gitignore line for Vagrant)
- build.sh sets up Ubuntu Trusty environment and builds a bootable kernel.img
- brief documentation of how to build and boot kernel.img