### PR TITLE
travis: use a build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: erlang
-otp_release: 17.5
+otp_release:
+  - 17.5
+env:
+  - ARCH=xen CONF=dbg
+  - ARCH=xen CONF=opt
+  - ARCH=xen CONF=lto
+  - ARCH=posix CONF=dbg
+  - ARCH=posix CONF=opt
+  - ARCH=posix CONF=lto
 script:
-  - make -j2 test ARCH=xen CONF=dbg
-  - make -j2 test ARCH=xen CONF=opt
-  - make -j2 test ARCH=xen CONF=lto
-  - make -j2 test ARCH=posix CONF=dbg
-  - make -j2 test ARCH=posix CONF=opt
-  - make -j2 play ARCH=posix CONF=lto
+  - make -j2 test ARCH=$ARCH CONF=$CONF
 sudo: false


### PR DESCRIPTION
~~This should make failures like [that one](https://github.com/cloudozer/ling/commit/31b9f706399be1c0d70d26e9c5fa7ef9d3639e23#commitcomment-12965010) more apparent.~~

The build matrix gives a better build UI and allows running multiple ling flavours in parallel in a clean environment.